### PR TITLE
win 10 compatible fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - LOG_LEVEL=debug
     links:
       - db
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
 
   db:
     restart: always
@@ -24,6 +22,4 @@ services:
     environment:
       - POSTGRES_USER=adamant_main
       - POSTGRES_PASSWORD=password
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
       


### PR DESCRIPTION
Volume mappings does not work for postgres with Docker for Windows